### PR TITLE
Fix/expect4337 revert error string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ docs/
 # Dotenv file
 .env
 node_modules
+
+gas_calculations/**.json

--- a/src/test/ModuleKitHelpers.sol
+++ b/src/test/ModuleKitHelpers.sol
@@ -164,7 +164,7 @@ library ModuleKitHelpers {
     }
 
     function expect4337Revert(AccountInstance memory) internal {
-        writeExpectRevert(abi.encode(1));
+        writeExpectRevert("");
     }
 
     function expect4337Revert(AccountInstance memory, bytes memory message) internal {

--- a/src/test/utils/ERC4337Helpers.sol
+++ b/src/test/utils/ERC4337Helpers.sol
@@ -33,9 +33,10 @@ library ERC4337Helpers {
         bytes memory userOpCalldata = abi.encodeCall(IEntryPoint.handleOps, (userOps, beneficiary));
         (bool success,) = address(onEntryPoint).call(userOpCalldata);
 
-        uint256 isExpectRevert = abi.decode(getExpectRevert(), (uint256));
-        if (isExpectRevert == 0) {
+        uint256 isExpectRevert = getExpectRevert();
+        if (isExpectRevert != 0) {
             require(success, "UserOperation execution failed");
+            // todo: check message
         }
 
         // Parse logs and determine if a revert happened
@@ -58,20 +59,18 @@ library ERC4337Helpers {
                             userOpHash, address(bytes20(logs[i].topics[2])), nonce, revertReason
                         );
                     } else {
-                        writeExpectRevert(abi.encode(0));
+                        clearExpectRevert();
                     }
                 }
             }
         }
-        isExpectRevert = abi.decode(getExpectRevert(), (uint256));
+        isExpectRevert = getExpectRevert();
         if (isExpectRevert != 0) {
             if (success) {
                 revert("UserOperation did not revert");
-            } else {
-                require(!success, "UserOperation execution did not fail as expected");
             }
         }
-        writeExpectRevert(abi.encode(0));
+        clearExpectRevert();
 
         // Calculate gas for userOp
         string memory gasIdentifier = getGasIdentifier();

--- a/src/test/utils/ERC4337Helpers.sol
+++ b/src/test/utils/ERC4337Helpers.sol
@@ -55,6 +55,7 @@ library ERC4337Helpers {
                     if (isExpectRevert == 0) {
                         bytes32 userOpHash = logs[i].topics[1];
                         bytes memory revertReason = getUserOpRevertReason(logs, userOpHash);
+                        // todo: check message
                         revert UserOperationReverted(
                             userOpHash, address(bytes20(logs[i].topics[2])), nonce, revertReason
                         );

--- a/src/test/utils/Log.sol
+++ b/src/test/utils/Log.sol
@@ -2,14 +2,43 @@
 pragma solidity ^0.8.23;
 
 function writeExpectRevert(bytes memory message) {
+    uint256 value = 1;
+
+    if (message.length > 0) {
+        value = 2;
+        bytes32 slot = keccak256("ModuleKit.ExpectMessageSlot");
+        assembly {
+            sstore(slot, message)
+        }
+    }
+
     bytes32 slot = keccak256("ModuleKit.ExpectSlot");
     assembly {
-        sstore(slot, message)
+        sstore(slot, value)
     }
 }
 
-function getExpectRevert() view returns (bytes memory data) {
+function clearExpectRevert() {
     bytes32 slot = keccak256("ModuleKit.ExpectSlot");
+    assembly {
+        sstore(slot, 0)
+    }
+
+    slot = keccak256("ModuleKit.ExpectMessageSlot");
+    assembly {
+        sstore(slot, 0)
+    }
+}
+
+function getExpectRevert() view returns (uint256 value) {
+    bytes32 slot = keccak256("ModuleKit.ExpectSlot");
+    assembly {
+        value := sload(slot)
+    }
+}
+
+function getExpectRevertMessage() view returns (bytes memory data) {
+    bytes32 slot = keccak256("ModuleKit.ExpectMessageSlot");
     assembly {
         data := sload(slot)
     }

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -323,23 +323,32 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
 
     function testExpect4337Revert__WhenNoErrorMsg() public {
         instance.expect4337Revert();
-        bytes memory isExpectRevert = getExpectRevert();
-        assertEq(isExpectRevert, abi.encode(1));
+
+        uint256 isExpectRevert = getExpectRevert();
+        assertEq(isExpectRevert, 1);
     }
 
     function testExpect4337Revert__WhenBytes4ErrorMsg() public {
         bytes4 message = 0x12345678;
         AccountInstance memory instance_ = instance;
         instance_.expect4337Revert(message);
-        bytes4 isExpectRevert = abi.decode(getExpectRevert(), (bytes4));
-        assertEq(isExpectRevert, message);
+
+        uint256 isExpectRevert = getExpectRevert();
+        assertEq(isExpectRevert, 2);
+
+        bytes4 expectRevertMessage = abi.decode(getExpectRevertMessage(), (bytes4));
+        assertEq(expectRevertMessage, message);
     }
 
     function testExpect4337Revert__WhenBytesErrorMsg() public {
         bytes memory message = abi.encode("UserOperation execution failed");
         AccountInstance memory instance_ = instance;
         instance_.expect4337Revert(message);
-        bytes memory isExpectRevert = getExpectRevert();
-        assertEq(isExpectRevert, message);
+
+        uint256 isExpectRevert = getExpectRevert();
+        assertEq(isExpectRevert, 2);
+
+        bytes memory expectRevertMessage = getExpectRevertMessage();
+        assertEq(expectRevertMessage, message);
     }
 }


### PR DESCRIPTION
fixes the weird behaviour of the revert data in storage by:
- using one slot to store expect revert (1 if no data, 2 if data)
- using another slot to store the data
- adding a new function to clear the revert

all tests are passing and it seems like it behaves as expected; the only thing missing is checking the revert message if expectrevert is 2